### PR TITLE
fix: platform parity, grant-writing name, release prep for 2.6.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "co-researcher",
       "source": "./",
       "description": "PhD-level research capabilities: literature review, multi-source investigation, critical analysis, hypothesis-driven exploration, quantitative/qualitative methods",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "author": {
         "name": "poemswe"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "co-researcher",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "PhD-level research capabilities: literature review, multi-source investigation, critical analysis, hypothesis-driven exploration, quantitative/qualitative methods",
   "author": {
     "name": "poemswe"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "co-researcher",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "PhD-level research capabilities: literature review, multi-source investigation, critical analysis, hypothesis-driven exploration, quantitative/qualitative methods, peer review, ethics review, and grant writing",
   "author": {
     "name": "poemswe"

--- a/KnowledgeGraph.md
+++ b/KnowledgeGraph.md
@@ -25,7 +25,7 @@ Domain-expert skills provide PhD-level research capabilities:
 
 ### Platform Integration
 
-**Current Version: v2.6.0**
+**Current Version: v2.6.1**
 
 The system supports four CLI platforms through unified skill definitions. `skills/` is the single source of truth; each platform ships only a loader and a context file that injects the three Systemic Honesty principles:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Co-Researcher (v2.6.0)
+# Co-Researcher (v2.6.1)
 
 A professional research suite for conducting rigorous academic research using specialized agents and multi-platform CLI commands. Compatible with **Claude Code**, **Gemini CLI**, **OpenAI Codex**, and **OpenCode**.
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -46,7 +46,7 @@ python run_eval.py literature-reviewer -v            # Verbose output
 | | fallacy-detection | Medium |
 | | methodology-critique | Medium |
 | **ethics-review** | privacy-risk | Hard |
-| **grant-proposal** | grant-proposal | Medium |
+| **grant-writing** | grant-writing | Medium |
 | **hypothesis-testing** | hypothesis-formulation | Medium |
 | | unfalsifiable-claim | Hard |
 | | variable-mapping | Hard |

--- a/evals/test-cases/grant-writing/test-grant-proposal.md
+++ b/evals/test-cases/grant-writing/test-grant-proposal.md
@@ -1,7 +1,7 @@
 # Test Case: Grant Proposal Structure (Grant Writer)
 
 ## Metadata
-- **Agent**: grant-proposal
+- **Agent**: grant-writing
 - **Difficulty**: Medium
 - **Area**: Grant Development
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
     "name": "co-researcher",
-    "version": "2.6.0",
+    "version": "2.6.1",
     "description": "PhD-level co-researcher suite for systematic reviews, critical analysis, and academic writing.",
     "author": "poemswe",
     "license": "MIT",

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
       "url": "https://coresearcher.poemswe.com/",
       "applicationCategory": "ResearchTool",
       "operatingSystem": "Claude Code, Gemini CLI, OpenAI Codex, OpenCode",
-      "softwareVersion": "2.6.0",
+      "softwareVersion": "2.6.1",
       "offers": {
         "@type": "Offer",
         "price": "0",
@@ -573,7 +573,7 @@
 </nav>
 
 <section class="hero">
-    <p class="hero-label">Co-Researcher v2.6 — Claude Code · Gemini CLI · OpenAI Codex · OpenCode</p>
+    <p class="hero-label">Co-Researcher v2.6.1 — Claude Code · Gemini CLI · OpenAI Codex · OpenCode</p>
     <h1>Your agent just cited<br>a paper that <em>doesn't exist.</em><br>Give it a protocol.</h1>
     <p class="hero-body">Fourteen research protocols — literature review, critical analysis, hypothesis testing, systematic review — installed natively into your AI CLI.</p>
     <div class="hero-actions">

--- a/skills/grant-writing/SKILL.md
+++ b/skills/grant-writing/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: grant-proposal
+name: grant-writing
 description: You must use this when drafting grant proposals, refining research aims, or aligning projects with agency priorities.
 tools:
   - WebSearch


### PR DESCRIPTION
Consolidates the post-2.6.0 corrections and prepares the release. (The three platform commits already on `main` were pushed without a PR — a process miss; this PR carries the review they should have had, plus the remaining fixes.)

**Verification that earned its keep.** Checking my own unverified claim that "Gemini reads `skills/`" — by actually running `gemini skills list` — confirmed discovery works *and* surfaced a real bug: `skills/grant-writing/` carried frontmatter `name: grant-proposal`. Claude keys skills by directory, Gemini by frontmatter name, so Gemini registered it as `grant-proposal` while every doc said `grant-writing`. A user reading GEMINI.md and invoking `grant-writing` got nothing. Fixed; `gemini skills list` now shows all 15 with names matching their directories.

**Platform parity.** Codex, Gemini, and OpenCode now inject the three Systemic Honesty principles that previously only Claude received via its SessionStart hook — the product's core promise was Claude-only. Plus the "never present an unverified bibliography" rule and a `uv` prerequisite. Wording verified byte-identical across all four context files.

**Cleanup.** Deleted `.codex/skills/` (8 dead duplicate files the launcher never loaded, drifted stale). Removed dead symbols from the OpenCode plugin. Rewrote GEMINI.md (duplicated block, listed 9 of 15 skills, referenced a nonexistent `agents/` dir). Corrected KnowledgeGraph (said three platforms, omitted OpenCode) and README architecture.

No new scripts, skills, or features — hence a patch. 125 Python tests unaffected and passing. Independent review: ready to merge.