### PR TITLE
Fix Windows compatibility and reduce rate-limiter lock hold time

### DIFF
--- a/skills/literature-review/scripts/http_client.py
+++ b/skills/literature-review/scripts/http_client.py
@@ -30,11 +30,11 @@ from __future__ import annotations
 import contextlib
 import datetime
 import email.utils
-import fcntl
 import gzip
 import json
 import os
 import random
+import tempfile
 import time
 from typing import Any
 import urllib.error
@@ -47,7 +47,7 @@ DEFAULT_MAX_RETRIES = 7
 DEFAULT_BACKOFF_BASE_SECS = 3.0
 DEFAULT_BACKOFF_MAX_SECS = 180.0
 DEFAULT_JITTER_SECS = 0.5
-_LOCK_PREFIX = "/tmp/co-researcher-httpclient"
+_LOCK_PREFIX = os.path.join(tempfile.gettempdir(), "co-researcher-httpclient")
 _REFERER_TEMPLATE = (
     "https://github.com/poemswe/co-researcher/tree/main/skills/{skill}"
 )
@@ -105,24 +105,38 @@ class _RateLimiter:
 
   def __init__(self, hostname, qps):
     self._min_gap = 1.0 / qps
-    self._lock_path = f"{_LOCK_PREFIX}-{hostname}.lock"
+    self._lock_dir = f"{_LOCK_PREFIX}-{hostname}.lockdir"
+    self._state_path = f"{_LOCK_PREFIX}-{hostname}.state"
+
+  def _acquire(self):
+    while True:
+      try:
+        os.mkdir(self._lock_dir)
+        return
+      except FileExistsError:
+        time.sleep(0.01)
+
+  def _release(self):
+    with contextlib.suppress(OSError):
+      os.rmdir(self._lock_dir)
 
   def wait(self):
-    with open(self._lock_path, "a+") as handle:
-      fcntl.flock(handle, fcntl.LOCK_EX)
-      try:
-        handle.seek(0)
-        raw = handle.read().strip()
-        previous = float(raw) if raw else 0.0
-        gap = self._min_gap - (time.monotonic() - previous)
-        if gap > 0:
-          time.sleep(gap)
-        handle.seek(0)
-        handle.truncate()
-        handle.write(str(time.monotonic()))
-        handle.flush()
-      finally:
-        fcntl.flock(handle, fcntl.LOCK_UN)
+    self._acquire()
+    try:
+      previous = 0.0
+      if os.path.exists(self._state_path):
+        with open(self._state_path) as handle:
+          raw = handle.read().strip()
+          previous = float(raw) if raw else 0.0
+      reserved = max(time.monotonic(), previous + self._min_gap)
+      with open(self._state_path, "w") as handle:
+        handle.write(str(reserved))
+    finally:
+      self._release()
+
+    gap = reserved - time.monotonic()
+    if gap > 0:
+      time.sleep(gap)
 
 
 def _retry_after_secs(headers):


### PR DESCRIPTION
## Problem

\`http_client._RateLimiter\` imports \`fcntl\` at module load time. \`fcntl\` is POSIX-only, so every script that imports \`http_client\` (\`openalex_cli.py\`, \`search_arxiv.py\`, \`europepmc_api.py\`) fails immediately on Windows with \`ModuleNotFoundError\`, before any request is made. The lock-file prefix was also hardcoded to \`/tmp\`, which doesn't exist on Windows.

## Fix

Replace the \`fcntl.flock\` mutex with one built from \`os.mkdir\`, which is atomic on POSIX and Windows alike — a single implementation instead of a \`sys.platform\` branch (avoids the more fiddly \`msvcrt.locking\` API, which locks a byte range rather than offering a simple exclusive/shared lock). Lock-file prefix now comes from \`tempfile.gettempdir()\`.

## Also: shrink the critical section

While patching this, I noticed the lock was held for the *entire* inter-request sleep, not just the read/write of the shared state. A second process waiting on the same host would spin-poll \`os.mkdir\` every 10ms for up to the full rate-limit gap (e.g. 3s for arXiv) instead of just blocking briefly. This patch reserves the next allowed slot (\`max(now, previous + min_gap)\`) while holding the lock, releases immediately, then sleeps outside the critical section — the lock is now held for microseconds. As a side effect, concurrent waiters get distinct reserved slots instead of all computing the same gap and re-colliding on the same wake time.

## Testing

Verified on Windows: \`openalex_cli.py\`, \`search_arxiv.py\`, and \`europepmc_api.py\` all import and run correctly with this patch (they failed with \`ModuleNotFoundError: fcntl\` before). Ran real searches end-to-end as part of a literature review to confirm requests, rate limiting, and retries still behave correctly.

No new dependencies — stays stdlib-only like the rest of the script.