### PR TITLE
Fix resolve_title failing on titles containing a comma

### DIFF
--- a/skills/literature-review/scripts/verify_citations.py
+++ b/skills/literature-review/scripts/verify_citations.py
@@ -226,8 +226,9 @@ def retracted_via_epmc(pmid: str) -> bool | None:
 
 
 def resolve_title(title: str) -> dict | None:
+  safe_title = title.replace('"', "'")
   query = urllib.parse.urlencode(
-      {"filter": f"title.search:{title}", "per-page": 1})
+      {"filter": f'title.search:"{safe_title}"', "per-page": 1})
   try:
     data = _OPENALEX.fetch_json(f"https://api.openalex.org/works?{query}")
   except http_client.HttpError as err:


### PR DESCRIPTION
## Problem

OpenAlex's filter mini-language uses commas to separate multiple filters within one \`filter=\` parameter. \`resolve_title()\` interpolates the raw title into \`title.search:<title>\` and relies on \`urlencode\`'s percent-encoding to handle a literal comma in the title (common in academic titles with a subtitle, e.g. *"OxyMake: A Formally-Specified, Content-Addressable Workflow Engine"*).

This doesn't work: OpenAlex's API edge rejects the request even when the comma is correctly percent-encoded as \`%2C\`. I confirmed this directly against the live API with \`curl\`, independent of this codebase, so it isn't a bug in \`urlencode\`/\`http_client\` — the value has to be wrapped in double quotes instead, which is the second option OpenAlex's own error message names but the code doesn't use.

Without this fix, any title containing a comma comes back as \`"not_found"\` in the report — indistinguishable from a citation that genuinely doesn't exist, which is exactly the class of mistake the citation-verification gate exists to catch. A false \`not_found\` on a real, correctly-cited paper undermines trust in the gate on exactly the inputs (real academic titles) it's meant to protect.

## Fix

Quote the title in the filter value (\`title.search:"<title>"\`). Normalize any literal double quote in the title first so it can't prematurely close the quoted value.

## Testing

Reproduced the failure directly against the live OpenAlex API with \`curl\` (percent-encoded comma → 400; quoted value → 200 with the correct match). Ran \`verify_citations.py\` against a bibliography containing titles with commas before and after the fix: before, 2/6 came back \`not_found\`; after, 6/6 verified correctly.